### PR TITLE
Add Unit Tests for AirQuality Logic

### DIFF
--- a/GadgetBuddy/platformio.ini
+++ b/GadgetBuddy/platformio.ini
@@ -31,6 +31,7 @@ lib_deps =
 [env:native]
 platform = native
 test_framework = unity
+build_flags = -Itest
 lib_deps = 
 	throwtheswitch/Unity@^2.6.0
 	adafruit/DHT sensor library@^1.4.6

--- a/GadgetBuddy/platformio.ini
+++ b/GadgetBuddy/platformio.ini
@@ -31,7 +31,6 @@ lib_deps =
 [env:native]
 platform = native
 test_framework = unity
-build_flags = -Itest
 lib_deps = 
 	throwtheswitch/Unity@^2.6.0
 	adafruit/DHT sensor library@^1.4.6

--- a/GadgetBuddy/src/AirQuality/AirQuality.cpp
+++ b/GadgetBuddy/src/AirQuality/AirQuality.cpp
@@ -7,7 +7,7 @@
 #include "AirQuality.h"
 
 #ifdef PLATFORMIO_UNIT_TEST
-#include "mocks/MockArduino.h"
+#include "../mocks/MockArduino.h"
 #else
 #include <Arduino.h>
 #endif

--- a/GadgetBuddy/src/AirQuality/AirQuality.cpp
+++ b/GadgetBuddy/src/AirQuality/AirQuality.cpp
@@ -5,7 +5,12 @@
 */
 
 #include "AirQuality.h"
+
+#ifdef PLATFORMIO_UNIT_TEST
+#include "mocks/MockArduino.h"
+#else
 #include <Arduino.h>
+#endif
 
 const char* MQ_READ_ERROR_MSG = "MQ Read Error!";
 

--- a/GadgetBuddy/src/AirQuality/AirQuality.h
+++ b/GadgetBuddy/src/AirQuality/AirQuality.h
@@ -23,6 +23,11 @@ public:
 
     // Additional methods for better user experience
     const char* getAirQualityStatus() const;
+
+    // Calculations and validations needed
+    float calculatePPM(int adcReading);
+    bool validateSensorReading(float ppmValue);
+    float calculateResistance(int adcReading);
     
     // ErrorReportingInterface methods
     const char* getErrorMessage() override;
@@ -52,9 +57,7 @@ private:
 
     // Private helpers
     void performSensorReading();
-    bool validateSensorReading(float ppmValue);
     void updateErrorState(bool hasError);
-    float calculatePPM(int adcReading);
-    float calculateResistance(int adcReading);
+    
 };
 #endif

--- a/GadgetBuddy/test/airQualityTest/MockAirQuality.h
+++ b/GadgetBuddy/test/airQualityTest/MockAirQuality.h
@@ -1,0 +1,70 @@
+/**
+ * By: Frank Vanris
+ * Date: 8/26/2025
+ * Desc: Mocking the AirQuality sensor functions
+*/
+
+#pragma once
+
+#include "Interfaces/AirQualityInterface.h"
+#include <math.h>
+
+class MockAirQuality : public AirQualityInterface {
+public:
+    MockAirQuality() : mCO2_PPM(400.0f), mRawADCReading(512.0f), mR0(7600.0f), mHasError(false), mIsWarmedUp(true) {}
+
+    void setup() override {}
+    void loop() override {}
+
+    float getAirQualityData() const override { return mCO2_PPM; }
+    float getRawADCReading() const override { return mRawADCReading; }
+    float getR0Value() const override { return mR0; }
+
+    // Pure logic methods
+    float calculateResistance(int adcReading) {
+        float voltage = adcReading * (5.0f / 1023.0f);
+        if (voltage <= 0.01f) voltage = 0.01f;
+        return ((5.0f - voltage) / voltage) * 1000.0f;
+    }
+
+    float calculatePPM(int adcReading) {
+        float sensorResistance = calculateResistance(adcReading);
+        float ratio = sensorResistance / mR0;
+        if (ratio <= 0) return 0.0f;
+        float ppm = 110.47f * pow(ratio, -2.862f);
+        if (ppm < 1.0f) ppm = 1.0f;
+        if (ppm > 10000.0f) ppm = 10000.0f;
+        return ppm;
+    }
+
+    bool validateSensorReading(float ppmValue) {
+        if(isnan(ppmValue) || isinf(ppmValue)) return false;
+        if(ppmValue < 1.0f || ppmValue > 10000.0f) return false;
+        return true;
+    }
+
+    const char* getAirQualityStatus() const {
+        if(mHasError) return "ERROR  ";
+        if(!mIsWarmedUp) return "WARM UP  ";
+        if(mCO2_PPM < 25) return "EXCELLENT";
+        else if(mCO2_PPM < 30) return "VERY GOOD";
+        else if(mCO2_PPM < 40) return "GOOD     ";
+        else if(mCO2_PPM < 50) return "FAIR";
+        else if(mCO2_PPM < 60) return "POOR";
+        else if (mCO2_PPM < 70) return "BAD      ";
+        else return "HAZARDOUS";
+    }
+
+    // You can add error reporting methods if needed
+    bool hasError() const { return mHasError; }
+    void setError(bool err) { mHasError = err; }
+    void setWarmedUp(bool warm) { mIsWarmedUp = warm; }
+    void setCO2(float val) { mCO2_PPM = val; }
+
+private:
+    float mCO2_PPM;
+    float mRawADCReading;
+    float mR0;
+    bool mHasError;
+    bool mIsWarmedUp;
+};

--- a/GadgetBuddy/test/airQualityTest/airqualitytest.h
+++ b/GadgetBuddy/test/airQualityTest/airqualitytest.h
@@ -1,0 +1,16 @@
+/**
+ * By: Frank Vanris
+ * Date: 8/26/2025
+ * Desc: Creating Unit Tests for the AirQuality sensor
+ */
+
+ #pragma once
+
+ #include <unity.h>
+ #include "../mocks/MockArduino.h"
+ #include "AirQuality/AirQuality.h"
+
+ // Test calculateResistance logic
+ void test_calculate_resistance() {
+    
+ }

--- a/GadgetBuddy/test/airQualityTest/airqualitytest.h
+++ b/GadgetBuddy/test/airQualityTest/airqualitytest.h
@@ -8,9 +8,52 @@
 
  #include <unity.h>
  #include "../mocks/MockArduino.h"
- #include "AirQuality/AirQuality.h"
+ #include "MockAirQuality.h"
 
  // Test calculateResistance logic
  void test_calculate_resistance() {
-    
+    MockAirQuality aq;
+    float resistance = aq.calculateResistance(512);
+    TEST_ASSERT_TRUE(resistance > 0);
+ }
+
+ // Test calculatePPM logic
+ void test_calculate_ppm() {
+   MockAirQuality aq;
+    float ppm = aq.calculatePPM(512);
+    TEST_ASSERT_TRUE(ppm >= 1.0f && ppm <= 10000.0f);
+ }
+
+ // Test getAirQualityStatus logic
+ void test_get_air_quality_status() {
+    MockAirQuality aq;
+    aq.setCO2(20.0f);
+    aq.setError(false);
+    aq.setWarmedUp(true);
+    TEST_ASSERT_EQUAL_STRING("EXCELLENT", aq.getAirQualityStatus());
+
+    aq.setCO2(35.0f);
+    TEST_ASSERT_EQUAL_STRING("GOOD     ", aq.getAirQualityStatus());
+
+    aq.setError(true);
+    TEST_ASSERT_EQUAL_STRING("ERROR  ", aq.getAirQualityStatus());
+
+    aq.setError(false);
+    aq.setWarmedUp(false);
+    TEST_ASSERT_EQUAL_STRING("WARM UP  ", aq.getAirQualityStatus());
+}
+
+ // Test validateSensorReading logic
+ void test_validate_sensor_reading() {
+   MockAirQuality aq;
+    TEST_ASSERT_TRUE(aq.validateSensorReading(400.0f));
+    TEST_ASSERT_FALSE(aq.validateSensorReading(0.0f));
+    TEST_ASSERT_FALSE(aq.validateSensorReading(20000.0f));
+ }
+
+ void test_air_quality_methods(void) {
+    RUN_TEST(test_calculate_resistance);
+    RUN_TEST(test_calculate_ppm);
+    RUN_TEST(test_get_air_quality_status);
+    RUN_TEST(test_validate_sensor_reading);
  }

--- a/GadgetBuddy/test/mocks/MockArduino.h
+++ b/GadgetBuddy/test/mocks/MockArduino.h
@@ -1,0 +1,35 @@
+/**
+ * By: Frank Vanris
+ * Date: 8/26/2025
+ * Desc: Creating a mock Arduino class for testing purposes
+*/
+
+#pragma once
+
+// Mock analogRead: returns a fixed value for testing
+inline int analogRead(int pin) {
+    return 512;
+}
+
+// Mock millis: returns an incrementing value
+inline unsigned long millis() {
+    static unsigned long fakeMillis = 0;
+    fakeMillis += 100;
+    return fakeMillis;
+}
+
+// Mock delay: does nothing in native tests
+inline void delay(unsigned long ms) {
+
+}
+
+// Mock Serial: minimal stub
+struct MockSerial {
+    void begin(unsigned long) {}
+    void println(const char*) {}
+    void print(const char*) {}
+    void println(int) {}
+    void print(int) {}
+};
+
+static MockSerial Serial;

--- a/GadgetBuddy/test/test_native.cpp
+++ b/GadgetBuddy/test/test_native.cpp
@@ -3,6 +3,7 @@
 #include "circularBufferTest/circularbuffertest.h"
 #include "tempHumidSensorTest/temphumidsensortest.h"
 #include "buttonsTest/buttonstest.h"
+#include "airQualityTest/airqualitytest.h"
 // Functions to test and setup environment if needed.
 void setUp(void) {}
 
@@ -14,6 +15,7 @@ int runUnityTests(void) {
     UNITY_BEGIN();
     test_basic_math_operations();
     test_circular_buffer_methods();
+    test_air_quality_methods();
     test_temp_humid_sensor_methods();
     test_button_methods();
     return UNITY_END();


### PR DESCRIPTION
### Summary
This PR adds comprehensive unit tests for the AirQuality logic using a mock implementation (`MockAirQuality`) that avoids hardware dependencies.  
Tests cover resistance calculation, PPM calculation, sensor reading validation, and air quality status reporting.

---

### Changes

- **Added:**  
  `test/airQualityTest/MockAirQuality.h`  
  - Implements `AirQualityInterface` with pure logic methods for testing.

- **Added:**  
  `test/airQualityTest/airqualitytest.h`  
  - Contains Unity-based unit tests for:
    - `calculateResistance`
    - `calculatePPM`
    - `validateSensorReading`
    - `getAirQualityStatus`

- **Updated:**  
  `test/test_native.cpp`  
  - Calls `test_air_quality_methods()` to run all AirQuality logic tests.

---

### How to Run

```sh
pio test -e native